### PR TITLE
Writing Error Messages to Standard Error Instead of Standard Output.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,13 +5,13 @@ fn main() {
     // Позволяем программе читать любые переданные ей аргументы командной строки,
     let args: Vec<String> = env::args().collect();  // а затем собирать значения в вектор.
     let config = Config::build(&args).unwrap_or_else(|err| {
-        println!("Problem parsing arguments: {err}");
+        eprintln!("Problem parsing arguments: {err}");
         process::exit(1);           // немедленно остановит программу и вернёт номер,
                                          // который был передан в качестве кода состояния выхода.
     });
 
     if let Err(e) = minigrep::run(config) {   // if let используется, чтобы проверить возвращает ли run значение Err
-        println!("Application error: {e}");
+        eprintln!("Application error: {e}");
         process::exit(1);
     }
 }


### PR DESCRIPTION
Запись сообщений ошибок в поток ошибок вместо стандартного потока вывода. Changed println!() to eprintln!()